### PR TITLE
added contact details for chaplain, reader und churchwardens

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,11 +12,12 @@ Patch: Everything else → bumps patch version (1.0.0 → 1.0.1)
 
 ### Added
 
--
+- contact details for the chaplain
+- added chaplaincy emails for all churchwardens and reader
 
 ### Changed
 
--
+- minor adjustments to the padding of the profile cards
 
 ### Fixed
 

--- a/src/lib/components/ProfileCard.svelte
+++ b/src/lib/components/ProfileCard.svelte
@@ -30,7 +30,8 @@
 
 {#if screenWidth > 1024}
 	<div
-		class="profile-card my-10 flex w-full {imagePosition === 'left'
+		id="profile-card"
+		class="my-10 flex w-full p-6 {imagePosition === 'left'
 			? 'flex-row'
 			: 'flex-row-reverse'}  rounded-xl border border-slate-200 shadow-xl"
 	>
@@ -42,7 +43,7 @@
 		</div>
 	</div>
 {:else}
-	<div class="profile-card-mobile my-6 flex w-full flex-col rounded-xl border border-slate-200 shadow-xl sm:my-10">
+	<div id="profile-card-mobile" class="my-6 flex w-full flex-col rounded-xl border border-slate-200 shadow-xl sm:my-10">
 		<div class="flwx-row flex w-full">
 			<div class="profile-image-and-name">
 				<ProfileImage {photo} />

--- a/src/lib/data/data.json
+++ b/src/lib/data/data.json
@@ -29,43 +29,43 @@
 		{
 			"name": "Richard Gardiner",
 			"role": "Chaplain",
-			"description": "",
+			"description": "<strong>Contact details</strong><p>Mobile: 0172 5328025<br>Landline: 02247 1472<br>E-Mail: <a href=\"mailto:richard.gardiner@web.de\">richard.gardiner@web.de</a></p>",
 			"photoUrl": "https://firebasestorage.googleapis.com/v0/b/chaplaincy-website-prod.appspot.com/o/images%2Fprofiles%2Frichardgardiner_xs.jpg?alt=media&token=9601c70a-ff9b-48d5-b1f6-266bb5da858e"
 		},
 		{
 			"name": "Jenny Knudsen",
 			"role": "Reader & Communications",
-			"description": "Jenny is licenced to the chaplaincy as a Reader (also known as Licenced Lay Minister). She also co-leads the St Boniface Sunday School and is the chaplaincy's social media admin. ",
+			"description": "Jenny is licenced to the chaplaincy as a Reader (also known as Licenced Lay Minister). She also co-leads the St Boniface Sunday School and is the chaplaincy's social media admin. <p><hr class=\"py-2 w-[80%]\"><strong>Contact details</strong><p>E-Mail: <a href=\"mailto:readerjenny@anglicanbonncologne.de\">readerjenny@anglicanbonncologne.de</a></p>",
 			"photoUrl": "https://firebasestorage.googleapis.com/v0/b/chaplaincy-website-prod.appspot.com/o/images%2Fprofiles%2Fjennyknudsen.jpeg?alt=media&token=da524693-d014-4362-b308-1993f8df767e"
 		},
 		{
 			"name": "Hamish Cooper",
 			"role": "Churchwarden in Bonn",
-			"description": "",
+			"description": "<strong>Contact details</strong><p>E-Mail: <a href=\"mailto:cwhamish@anglicanbonncologne.de\">cwhamish@anglicanbonncologne.de</a></p>",
 			"photoUrl": "https://firebasestorage.googleapis.com/v0/b/chaplaincy-website-prod.appspot.com/o/images%2Fprofiles%2Fhamishcooper.JPG?alt=media&token=f70cfcfd-73f1-4299-a65a-f9b135f85387"
 		},
 		{
 			"name": "Annette Klever",
 			"role": "Churchwarden in Cologne",
-			"description": "What has been done, has been done;<br> What has not been done, has not been done. <br>Let it be.",
+			"description": "What has been done, has been done;<br> What has not been done, has not been done. <br>Let it be.<p><hr class=\"py-2 w-[80%]\"><strong>Contact details</strong><p>E-Mail: <a href=\"mailto:cwannette@anglicanbonncologne.de\">cwannette@anglicanbonncologne.de</a></p>",
 			"photoUrl": "https://firebasestorage.googleapis.com/v0/b/chaplaincy-website-prod.appspot.com/o/images%2Fprofiles%2Fannetteklever.jpeg?alt=media&token=2c95ed69-d937-45a8-9a46-db7880bdb7e1"
 		},
 		{
 			"name": "Reiner Knudsen",
 			"role": "Churchwarden in Bonn & Webmaster",
-			"description": "My goal is to make everybody feel welcome, included, and safe in our services and our chaplaincy's events.",
+			"description": "My goal is to make everybody feel welcome, included, and safe in our services and our chaplaincy's events.<p><hr class=\"py-2 w-[80%]\"><strong>Contact details</strong><p>E-Mail: <a href=\"mailto:cwreiner@anglicanbonncologne.de\">cwreiner@anglicanbonncologne.de</a></p>",
 			"photoUrl": "https://firebasestorage.googleapis.com/v0/b/chaplaincy-website-prod.appspot.com/o/images%2Fprofiles%2Freinerknudsen.jpeg?alt=media&token=73be19b2-767d-460f-970f-037fefcd9ae0"
 		},
 		{
 			"name": "Markus Müller",
 			"role": "Churchwarden in Cologne",
-			"description": "",
+			"description": "<strong>Contact details</strong><p>E-Mail: <a href=\"mailto:cwmarkus@anglicanbonncologne.de\">cwmarkus@anglicanbonncologne.de</a></p>",
 			"photoUrl": "https://firebasestorage.googleapis.com/v0/b/chaplaincy-website-prod.appspot.com/o/images%2Fprofiles%2Fplaceholderman_sm.jpeg?alt=media&token=254eec4a-8b00-46c7-83cf-675febf975a8"
 		},
 		{
 			"name": "Patra Al-Saadi",
 			"role": "Safeguarding Officer",
-			"description": "",
+			"description": "<strong>Contact details</strong><p>E-Mail: <a href=\"mailto:safeguarding@anglicanbonncologne.de\">safeguarding@anglicanbonncologne.de</a></p>",
 			"photoUrl": "https://firebasestorage.googleapis.com/v0/b/chaplaincy-website-prod.appspot.com/o/images%2Fprofiles%2Fplaceholderman_sm.jpeg?alt=media&token=254eec4a-8b00-46c7-83cf-675febf975a8"
 		}
 	],


### PR DESCRIPTION
Added contact details
- for chaplain
- for reader
- for churchwardens
- for safeguardíng officer



## 📋 Changelog

### Added
- contact details for the chaplain
- added chaplaincy emails for all churchwardens and reader
### Changed
- minor adjustments to the padding of the profile cards
### Fixed