### PR TITLE
Changes to list item button

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,7 +16,7 @@ Patch: Everything else → bumps patch version (1.0.0 → 1.0.1)
 
 ### Changed
 
--
+- The items in the list of documents in the admin center are now aligned to the left 
 
 ### Fixed
 

--- a/src/lib/components/ui/button/button.svelte
+++ b/src/lib/components/ui/button/button.svelte
@@ -17,6 +17,8 @@
 				menu: 'justify-center hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 text-xl font-semibold min-w-0 gap-0',
 				ghost: 'justify-center hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
 				link: 'justify-center text-primary underline underline-offset-4 hover:font-semibold hover:text-lg',
+				listItem:
+					'justify-left pl-2 w-full text-primary underline underline-offset-6 hover:font-semibold hover:text-lg hover:text-bold',
 				active: 'bg-secondary-40 w-full rounded-md py-4 px-2 text-left border-b hover:bg-secondary-60',
 				inactive: 'hover:bg-secondary-40 w-full rounded-md border-b bg-white px-2 py-4',
 				calltoaction:

--- a/src/routes/(admin)/admin/eventsadmin/+page.svelte
+++ b/src/routes/(admin)/admin/eventsadmin/+page.svelte
@@ -213,7 +213,7 @@
 					{#each $sortItems as item}
 						<tr class="table-row">
 							<td class="table-data table-cell">
-								<Button variant="link" onclick={() => handleOpenItem(item.id)}>
+								<Button variant="listItem" onclick={() => handleOpenItem(item.id)}>
 									{item.data.title}
 								</Button>
 							</td>

--- a/src/routes/(admin)/admin/newsadmin/+page.svelte
+++ b/src/routes/(admin)/admin/newsadmin/+page.svelte
@@ -173,7 +173,7 @@
 					{#each $sortItems as item}
 						<tr class="table-row">
 							<td class="table-data table-cell">
-								<Button variant="link" onclick={() => handleOpenItem(item.id)}>{item.data.title}</Button>
+								<Button variant="listItem" onclick={() => handleOpenItem(item.id)}>{item.data.title}</Button>
 							</td>
 							<td class="table-data table-cell">{decodeHtml(item.data.text)}</td>
 							<td class="table-data table-cell">{item.data.publishdate}</td>

--- a/src/routes/(admin)/admin/weeklysheet/+page.svelte
+++ b/src/routes/(admin)/admin/weeklysheet/+page.svelte
@@ -86,7 +86,8 @@
 					<tr class="table-row">
 						<td class="table-data table-cell">{item.date}</td>
 						<td class="table-data table-cell"
-							><Button variant="link"><a href={item.path} target="_blank">Open in browser</a></Button></td
+							><Button variant="listItem" class="pl-0"><a href={item.path} target="_blank">Open in browser</a></Button
+							></td
 						>
 					</tr>
 				{/each}


### PR DESCRIPTION
changed the button text to left alignment && used the new button variant in admin pages

## 📋 Changelog

### Added
### Changed
- The items in the list of documents in the admin center are now aligned to the left 
### Fixed