### PR TITLE
fixed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,7 +20,7 @@ Patch: Everything else → bumps patch version (1.0.0 → 1.0.1)
 
 ### Fixed
 
--
+- the filter preferred the wrong weekly sheet in a situation where two weekly sheets were "published"
 
 ## [5.1.1] - 2025-10-21
 

--- a/src/lib/stores/ObjectStore.ts
+++ b/src/lib/stores/ObjectStore.ts
@@ -456,6 +456,7 @@ export const getNextSunday = (): Date => {
 
 export const loadWeeklySheet = async () => {
 	const now = Timestamp.now();
+	const today = Timestamp.fromDate(new Date());
 
 	try {
 		const q = query(
@@ -463,7 +464,8 @@ export const loadWeeklySheet = async () => {
 			where('type', '==', 'weeklysheet'),
 			where('publishdate', '<=', now), // ✅ Published
 			where('unpublishdate', '>=', now), // ✅ Not yet unpublished
-			orderBy('date', 'asc'), // ✅ Earliest Sunday first (next Sunday)
+			where('date', '>=', today), // ✅ Sunday date is today or future
+			orderBy('date', 'asc'), // ✅ Earliest upcoming Sunday first
 			limit(1)
 		);
 		const querySnapshot = await getDocs(q);


### PR DESCRIPTION


## 📋 Changelog

### Added
### Changed
### Fixed
- the filter preferred the wrong weekly sheet in a situation where two weekly sheets were "published"