### PR TITLE
feat: Claude-generated alt text for uploaded images

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,11 +12,11 @@ Patch: Everything else → bumps patch version (1.0.0 → 1.0.1)
 
 ### Added
 
--
+- Claude-generated alt text drafts for uploaded images in News and Event forms
 
 ### Changed
 
--
+- Image upload limit increased from 600KB to 1.2MB
 
 ### Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -20,7 +20,7 @@ Patch: Everything else → bumps patch version (1.0.0 → 1.0.1)
 
 ### Fixed
 
--
+- Timezone bug: publish timestamps were stored as UTC instead of local time, causing a 1-2h delay before news/events appeared on the website
 
 ## [7.2.4] - 2026-05-17
 

--- a/changelog.md
+++ b/changelog.md
@@ -16,7 +16,7 @@ Patch: Everything else → bumps patch version (1.0.0 → 1.0.1)
 
 ### Changed
 
-- Image upload limit increased from 600KB to 1.2MB
+- Image upload limit increased from 600KB to 1.2MB; size display updated to MB
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
 	"name": "chaplaincy-domain",
-	"version": "7.2.3",
+	"version": "7.2.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "chaplaincy-domain",
-			"version": "7.2.3",
+			"version": "7.2.4",
 			"dependencies": {
+				"@anthropic-ai/sdk": "^0.96.0",
 				"@fontsource-variable/raleway": "^5.0.18",
 				"@fontsource/inter": "^5.1.0",
 				"@fortawesome/free-regular-svg-icons": "^6.5.2",
@@ -83,6 +84,36 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.96.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.96.0.tgz",
+			"integrity": "sha512-KlCsODtTyb17bLUVCSDC2HtSvAbJf60sEiPEax9dInF+aDF92vS4TZJ5XD7YCQXNb1/5icYaw8Y7wMjPlIV9Zg==",
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1",
+				"standardwebhooks": "^1.0.0"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -1978,6 +2009,12 @@
 			"funding": {
 				"url": "https://ko-fi.com/killymxi"
 			}
+		},
+		"node_modules/@stablelib/base64": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+			"integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+			"license": "MIT"
 		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.0.0",
@@ -4779,6 +4816,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/fast-sha256": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+			"integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+			"license": "Unlicense"
+		},
 		"node_modules/faye-websocket": {
 			"version": "0.11.4",
 			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
@@ -5574,6 +5617,19 @@
 			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
@@ -6475,7 +6531,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
@@ -7685,6 +7741,16 @@
 			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
 			"license": "MIT"
 		},
+		"node_modules/standardwebhooks": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+			"integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+			"license": "MIT",
+			"dependencies": {
+				"@stablelib/base64": "^1.0.0",
+				"fast-sha256": "^1.3.0"
+			}
+		},
 		"node_modules/statuses": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -8130,6 +8196,12 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"license": "MIT"
+		},
 		"node_modules/ts-api-utils": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -8283,7 +8355,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/utils-merge": {
@@ -8686,7 +8758,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
 		"cookie": "^0.7.2"
 	},
 	"dependencies": {
+		"@anthropic-ai/sdk": "^0.96.0",
 		"@fontsource-variable/raleway": "^5.0.18",
 		"@fontsource/inter": "^5.1.0",
 		"@fortawesome/free-regular-svg-icons": "^6.5.2",

--- a/src/lib/components/EventForm.svelte
+++ b/src/lib/components/EventForm.svelte
@@ -27,6 +27,9 @@
 
 	import { MAX_SLUG_TEXT } from '$lib/utils/constants';
 	import { cleanText } from '$lib/utils/HTMLfunctions';
+	import { Messages } from '$lib/utils/messages';
+	import { generateAltText } from '$lib/utils/altTextUtils';
+	import { notificationStore } from '$lib/stores/notifications';
 
 	import { Button } from '$lib/components/ui/button';
 	import Checkbox from './Checkbox.svelte';
@@ -38,6 +41,7 @@
 	import NewLocationModal from './NewLocationModal.svelte';
 	import SlugText from './SlugText.svelte';
 	import StateLabel from './StateLabel.svelte';
+	import ToastContainer from '$lib/components/ToastContainer.svelte';
 	import UploadImage from '$lib/components/UploadImage.svelte';
 	import UploadPDF from '$lib/components/UploadPDF.svelte';
 
@@ -66,6 +70,7 @@
 	let hasPDF = $derived(!!thisEvent.pdfFile);
 	let showModal = $state(false);
 	let loading = $state(true);
+	let generatingAltText = $state(false);
 	let originalHash = $state('');
 	let hasUnsavedChanges = $state(false);
 
@@ -149,10 +154,20 @@
 		}
 	};
 
-	const handleNewFileSelected = (image: File) => {
+	const handleNewFileSelected = async (image: File) => {
 		newImage = image;
 		thisEvent = { ...thisEvent, image: image.name, imageAlt: '', imageCaption: '' };
 		checkForChanges();
+		generatingAltText = true;
+		try {
+			const suggestedAlt = await generateAltText(image);
+			thisEvent = { ...thisEvent, imageAlt: suggestedAlt };
+			checkForChanges();
+		} catch (_) {
+			notificationStore.addToast('warning', Messages.ALTTEXT_ERROR);
+		} finally {
+			generatingAltText = false;
+		}
 	};
 
 	const handleExistingPDFSelected = async (pdfRef: StorageReference) => {
@@ -512,18 +527,29 @@
 			</fieldset>
 
 			<!-- Image Alt Text-->
-			<fieldset disabled={!hasImage} class="imageMeta">
+			<fieldset disabled={!hasImage || generatingAltText} class="imageMeta">
 				<fieldset>
 					<Label for="imageAlt">Image Alt text *</Label>
-					<Input
-						type="text"
-						id="imageAlt"
-						bind:value={thisEvent.imageAlt}
-						onblur={checkForChanges}
-						required={hasImage}
-						disabled={!hasImage}
-						placeholder={hasImage ? 'Image Alt text' : 'Please select an image first'}
-					/>
+					<div class="relative">
+						<Input
+							type="text"
+							id="imageAlt"
+							bind:value={thisEvent.imageAlt}
+							onblur={checkForChanges}
+							required={hasImage}
+							disabled={!hasImage || generatingAltText}
+							placeholder={generatingAltText
+								? 'Generating alt text...'
+								: hasImage
+									? 'Image Alt text'
+									: 'Please select an image first'}
+						/>
+						{#if generatingAltText}
+							<div class="absolute inset-y-0 right-3 flex items-center">
+								<Icon icon="svg-spinners:3-dots-fade" class="h-5 w-5 text-slate-400" />
+							</div>
+						{/if}
+					</div>
 					<div class="explanation {!hasImage ? 'opacity-30' : 'opacity-100'}">
 						This text helps interpreting the image for visually impaired users.
 					</div>
@@ -600,6 +626,8 @@
 		</div>
 	</form>
 {/if}
+
+<ToastContainer />
 
 <style>
 	.form {

--- a/src/lib/components/NewsForm.svelte
+++ b/src/lib/components/NewsForm.svelte
@@ -19,6 +19,9 @@
 
 	import { MAX_SLUG_TEXT } from '$lib/utils/constants';
 	import { cleanText } from '$lib/utils/HTMLfunctions';
+	import { Messages } from '$lib/utils/messages';
+	import { generateAltText } from '$lib/utils/altTextUtils';
+	import { notificationStore } from '$lib/stores/notifications';
 
 	import { Button } from '$lib/components/ui/button';
 	import Editor from './Editor.svelte';
@@ -61,6 +64,7 @@
 	let currentHash = $state('');
 	let hasUnsavedChanges = $state(false);
 	let loading = $state(true);
+	let generatingAltText = $state(false);
 
 	onMount(() => {
 		if ($EditModeStore === EditMode.Update) {
@@ -114,10 +118,20 @@
 		}
 	};
 
-	const handleNewImageSelected = (image: File) => {
+	const handleNewImageSelected = async (image: File) => {
 		newImage = image;
 		thisNews = { ...thisNews, image: image.name, imageAlt: '', imageCaption: '' };
 		checkForChanges();
+		generatingAltText = true;
+		try {
+			const suggestedAlt = await generateAltText(image);
+			thisNews = { ...thisNews, imageAlt: suggestedAlt };
+			checkForChanges();
+		} catch (_) {
+			notificationStore.addToast('warning', Messages.ALTTEXT_ERROR);
+		} finally {
+			generatingAltText = false;
+		}
 	};
 
 	const handleExistingPDFSelected = async (pdfRef: StorageReference) => {
@@ -276,17 +290,28 @@
 				<!-- Image Alt Text-->
 				<div id="image-alt" class="imageMeta">
 					<div class="imageAlt">
-						<fieldset disabled={!hasImage}>
+						<fieldset disabled={!hasImage || generatingAltText}>
 							<Label for="imageAlt">Image Alt text *</Label>
-							<Input
-								type="text"
-								id="imageAlt"
-								bind:value={thisNews.imageAlt}
-								required={hasImage}
-								disabled={!hasImage}
-								placeholder={hasImage ? 'Image Alt text' : 'Please select an image first'}
-								onblur={checkForChanges}
-							/>
+							<div class="relative">
+								<Input
+									type="text"
+									id="imageAlt"
+									bind:value={thisNews.imageAlt}
+									required={hasImage}
+									disabled={!hasImage || generatingAltText}
+									placeholder={generatingAltText
+										? 'Generating alt text...'
+										: hasImage
+											? 'Image Alt text'
+											: 'Please select an image first'}
+									onblur={checkForChanges}
+								/>
+								{#if generatingAltText}
+									<div class="absolute inset-y-0 right-3 flex items-center">
+										<Icon icon="svg-spinners:3-dots-fade" class="h-5 w-5 text-slate-400" />
+									</div>
+								{/if}
+							</div>
 							<p class="explanation {!hasImage ? 'opacity-30' : 'opacity-100'}">
 								This text helps interpreting the image for visually impaired users.
 							</p>

--- a/src/lib/components/UploadImage.svelte
+++ b/src/lib/components/UploadImage.svelte
@@ -85,7 +85,7 @@
 			<input type="file" id="uploadFile" accept={authorizedExtensions} class="hidden" onchange={handleImageChange} />
 		</label>
 		<div class="mt-3 text-center text-sm">
-			(jpeg, jpg, png, webp, max {MAX_IMAGE_SIZE / 1000}KB)
+			(jpeg, jpg, png, webp, max {MAX_IMAGE_SIZE / 1000000}MB)
 		</div>
 		{#if imageMessage}
 			<!-- eslint-disable svelte/no-at-html-tags -->

--- a/src/lib/services/NewsFormService.ts
+++ b/src/lib/services/NewsFormService.ts
@@ -5,14 +5,11 @@ import { Timestamp } from 'firebase/firestore';
 
 export const newsFormService = async (newNews: News) => {
 	if (!newNews.publishdate) {
-		/* create current date as ISO strings */
+		/* create current date as local time strings */
 		const now = new Date();
-		const dateStr = now.toISOString().split('T')[0];
-		const timeStr = now.toLocaleTimeString('en-US', {
-			hour: '2-digit',
-			minute: '2-digit',
-			hour12: false,
-		});
+		const pad = (n: number) => String(n).padStart(2, '0');
+		const dateStr = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+		const timeStr = `${pad(now.getHours())}:${pad(now.getMinutes())}`;
 		/* set publish date and time */
 		newNews.publishdate = dateStr;
 		newNews.publishtime = timeStr;

--- a/src/lib/services/validateForm.ts
+++ b/src/lib/services/validateForm.ts
@@ -19,7 +19,7 @@ export function validateEmptyInput(formData: FormData): string[] {
 }
 
 export const buildTimeStamp = (date: string, time: string): Date => {
-	return new Date(`${date}T${time}Z`);
+	return new Date(`${date}T${time}`);
 };
 
 export function validateEventData(event: DomainEvent): boolean {

--- a/src/lib/utils/altTextUtils.ts
+++ b/src/lib/utils/altTextUtils.ts
@@ -1,0 +1,19 @@
+export const fileToBase64 = (file: File): Promise<string> =>
+	new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onload = () => resolve((reader.result as string).split(',')[1]);
+		reader.onerror = () => reject(reader.error);
+		reader.readAsDataURL(file);
+	});
+
+export const generateAltText = async (file: File): Promise<string> => {
+	const imageBase64 = await fileToBase64(file);
+	const response = await fetch('/api/generate-alt-text', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ imageBase64, mimeType: file.type }),
+	});
+	const data = await response.json();
+	if (!response.ok || data.error) throw new Error(data.message || 'Failed to generate alt text');
+	return data.altText as string;
+};

--- a/src/lib/utils/constants.ts
+++ b/src/lib/utils/constants.ts
@@ -1,5 +1,5 @@
 export const MAX_SLUG_TEXT = 250;
-export const MAX_IMAGE_SIZE = 600000;
+export const MAX_IMAGE_SIZE = 1200000;
 export const STORAGE_URL = `https://storage.cloud.google.com/${import.meta.env.VITE_STORAGEBUCKET}/`;
 export const STORAGE_IMAGES = STORAGE_URL + 'images/';
 

--- a/src/lib/utils/messages.ts
+++ b/src/lib/utils/messages.ts
@@ -9,4 +9,5 @@ export enum Messages {
 	DRAFTERROR = 'I failed to save that draft. Please try again.',
 	DUPLICATESUCCESS = 'I created a duplicate for you.',
 	DUPLICATEERROR = 'I failed to create a duplicate. Please try again.',
+	ALTTEXT_ERROR = 'Could not generate alt text automatically. Please enter it manually.',
 }

--- a/src/routes/api/generate-alt-text/+server.ts
+++ b/src/routes/api/generate-alt-text/+server.ts
@@ -1,0 +1,47 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { PRIVATE_ANTHROPIC_API_KEY } from '$env/static/private';
+import Anthropic from '@anthropic-ai/sdk';
+
+export const POST: RequestHandler = async ({ request }) => {
+	try {
+		const { imageBase64, mimeType } = await request.json();
+
+		if (!imageBase64 || !mimeType) {
+			return json({ error: true, message: 'imageBase64 and mimeType are required' }, { status: 400 });
+		}
+
+		const allowedTypes = ['image/jpeg', 'image/png', 'image/webp'];
+		if (!allowedTypes.includes(mimeType)) {
+			return json({ error: true, message: 'Unsupported image type' }, { status: 400 });
+		}
+
+		const client = new Anthropic({ apiKey: PRIVATE_ANTHROPIC_API_KEY });
+
+		const response = await client.messages.create({
+			model: 'claude-haiku-4-5-20251001',
+			max_tokens: 150,
+			messages: [
+				{
+					role: 'user',
+					content: [
+						{
+							type: 'image',
+							source: { type: 'base64', media_type: mimeType, data: imageBase64 },
+						},
+						{
+							type: 'text',
+							text: 'Write a concise, descriptive alt text for this image in 10–15 words. Describe what is shown objectively. Do not start with "Image of" or "Picture of". Return only the alt text, nothing else.',
+						},
+					],
+				},
+			],
+		});
+
+		const altText = (response.content[0] as { type: string; text: string }).text.trim();
+		return json({ success: true, altText });
+	} catch (error) {
+		console.error('Error generating alt text:', error);
+		return json({ error: true, message: 'Failed to generate alt text.' }, { status: 500 });
+	}
+};


### PR DESCRIPTION
Closes #420

## Summary

- New server-side API endpoint `/api/generate-alt-text` calls Claude Haiku (vision) with the base64-encoded image
- Shared utility `altTextUtils.ts` handles base64 conversion and the fetch call
- `NewsForm` and `EventForm` auto-fill the alt text field with the generated draft after image selection
- Spinner shown on the alt text input while generating; field is disabled until done
- Warning toast on API failure — field stays empty so user can fill manually
- Image upload limit raised from 600KB to 1.2MB

## Test plan

- [ ] News Admin → Create → upload image → alt text field shows spinner then auto-fills
- [ ] Event Admin → Create → upload image → same behaviour
- [ ] Verify generated text is editable before saving
- [ ] Verify existing image selection still loads stored alt text correctly
- [ ] Test error path (bad API key) → warning toast appears, field stays empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 📋 Changelog

### Added
- Claude-generated alt text drafts for uploaded images in News and Event forms
### Changed
- Image upload limit increased from 600KB to 1.2MB; size display updated to MB
### Fixed
- Timezone bug: publish timestamps were stored as UTC instead of local time, causing a 1-2h delay before news/events appeared on the website

### Added
- Claude-generated alt text drafts for uploaded images in News and Event forms
### Changed
- Image upload limit increased from 600KB to 1.2MB; size display updated to MB
### Fixed

### Added
- Claude-generated alt text drafts for uploaded images in News and Event forms
### Changed
- Image upload limit increased from 600KB to 1.2MB
### Fixed