### PR TITLE
feat: display app version in footer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,7 +12,7 @@ Patch: Everything else → bumps patch version (1.0.0 → 1.0.1)
 
 ### Added
 
--
+- App version displayed in footer, embedded from package.json at build time
 
 ### Changed
 

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="@sveltejs/kit" />
 
+declare const __APP_VERSION__: string;
+
 declare global {
 	namespace App {
 		// interface Error {}

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -74,7 +74,7 @@
 		<hr class="my-4 border-gray-200" />
 
 		<div class="flex flex-col items-center justify-between py-4 sm:flex-row">
-			<div class="text-gray-500">© {new Date().getFullYear()} Sleepy Panda</div>
+			<div class="text-gray-500">© {new Date().getFullYear()} Sleepy Panda &nbsp;·&nbsp; v{__APP_VERSION__}</div>
 			<div class="mt-4 flex space-x-6 sm:mt-0">
 				<a
 					href="https://www.facebook.com/AnglicanBonnCologne/"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,14 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
+import { readFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
 export default defineConfig({
 	plugins: [sveltekit()],
+	define: {
+		__APP_VERSION__: JSON.stringify(pkg.version),
+	},
 	resolve: {
 		extensions: ['.ts', '.js', '.svelte'],
 	},


### PR DESCRIPTION
## Summary

- App version is read from `package.json` at build time via Vite's `define`
- Displayed in the footer next to the copyright notice
- Always matches the deployed build — no runtime overhead, no API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 📋 Changelog

### Added
- App version displayed in footer, embedded from package.json at build time
### Changed
### Fixed