### PR TITLE
fix: uploadImage propagates Firebase errors instead of swallowing them

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,7 +21,8 @@ Patch: Any other tag or no tag → bumps patch version (1.0.0 → 1.0.1)
 
 ### Fixed
 
--
+- Fix: uploadImage in fileService no longer silently swallows Firebase errors — errors now propagate to callers so upload failures are correctly surfaced as error toasts to the user
+- Removed redundant double-null-check in uploadNewsImage and uploadEventImage
 
 ## [8.1.0] - 2026-06-06
 

--- a/src/lib/services/EventFormService.ts
+++ b/src/lib/services/EventFormService.ts
@@ -55,17 +55,31 @@ export const eventFormService = async (newEvent: DomainEvent) => {
 	return newEvent;
 };
 
+/**
+ * Uploads a new image for an event and updates the event object with the resulting URL.
+ *
+ * If no new image is provided, the event object is returned unchanged.
+ * Errors from the upload (Firebase failures, missing alt text, etc.) propagate
+ * to the caller — they are not caught here.
+ *
+ * @param event - The event to attach the image to
+ * @param newImage - The new image file to upload, or null if no image was selected
+ * @returns The event object, updated with the new image URL if an image was uploaded
+ * @throws Error if alt text is missing when an image is provided
+ * @throws Any Firebase error that occurs during the upload
+ */
 export const uploadEventImage = async (event: DomainEvent, newImage: File | null): Promise<DomainEvent> => {
 	if (!newImage) {
 		return event;
 	}
-	if (newImage) {
-		if (!event.imageAlt || event.imageAlt.trim() === '') {
-			throw new Error('Image alt text is required');
-		}
-		const result: ReturnType = await uploadImage(newImage, event.imageAlt, event.imageCaption || '');
-		event.image = result.url;
+
+	if (!event.imageAlt || event.imageAlt.trim() === '') {
+		throw new Error('Image alt text is required');
 	}
+
+	const result: ReturnType = await uploadImage(newImage, event.imageAlt, event.imageCaption || '');
+	event.image = result.url;
+
 	return event;
 };
 

--- a/src/lib/services/NewsFormService.ts
+++ b/src/lib/services/NewsFormService.ts
@@ -24,16 +24,30 @@ export const newsFormService = async (newNews: News) => {
 	return newNews;
 };
 
+/**
+ * Uploads a new image for a news item and updates the news object with the resulting URL.
+ *
+ * If no new image is provided, the news object is returned unchanged.
+ * Errors from the upload (Firebase failures, missing alt text, etc.) propagate
+ * to the caller — they are not caught here.
+ *
+ * @param news - The news item to attach the image to
+ * @param newImage - The new image file to upload, or null if no image was selected
+ * @returns The news object, updated with the new image URL if an image was uploaded
+ * @throws Error if alt text is missing when an image is provided
+ * @throws Any Firebase error that occurs during the upload
+ */
 export const uploadNewsImage = async (news: News, newImage: File | null): Promise<News> => {
 	if (!newImage) {
 		return news;
 	}
-	if (newImage) {
-		if (!news.imageAlt || news.imageAlt.trim() === '') {
-			throw new Error('Image alt text is required');
-		}
-		const result: ReturnType = await uploadImage(newImage, news.imageAlt, news.imageCaption || '');
-		news.image = result.url;
+
+	if (!news.imageAlt || news.imageAlt.trim() === '') {
+		throw new Error('Image alt text is required');
 	}
+
+	const result: ReturnType = await uploadImage(newImage, news.imageAlt, news.imageCaption || '');
+	news.image = result.url;
+
 	return news;
 };

--- a/src/lib/services/fileService.ts
+++ b/src/lib/services/fileService.ts
@@ -39,26 +39,34 @@ export type ReturnType = {
 	ref: StorageReference;
 };
 
-// Upload an image to Firebase storage
+/**
+ * Uploads an image file to Firebase Storage and records its metadata in Firestore.
+ *
+ * Errors from Firebase (network failures, quota exceeded, permission errors, etc.)
+ * are intentionally NOT caught here — they propagate to the caller so the caller
+ * can decide how to handle them (e.g. show a toast notification to the user).
+ *
+ * @param selectedImage - The image file to upload
+ * @param altText - Accessible description of the image (required, stored in Firestore)
+ * @param caption - Optional visible caption displayed below the image
+ * @returns An object containing the public download URL and the Firebase StorageReference
+ * @throws Any Firebase Storage or Firestore error that occurs during the upload
+ */
 export const uploadImage = async (selectedImage: File, altText: string, caption: string): Promise<ReturnType> => {
-	if (selectedImage) {
-		const storageRef = ref(storage, 'images/' + selectedImage.name);
-		try {
-			await uploadBytes(storageRef, selectedImage);
-			const imageUrl = await getDownloadURL(storageRef);
-			const imageRef = storageRef;
-			await setDoc(doc(database, FileType.Image, selectedImage.name), {
-				name: selectedImage.name,
-				url: imageUrl,
-				createdAt: new Date(),
-				altText: altText,
-				imageCaption: caption,
-			} as ImageDocument);
-			return { url: imageUrl, ref: imageRef };
-		} catch (error) {
-			console.error(error);
-		}
-	}
+	const storageRef = ref(storage, 'images/' + selectedImage.name);
+
+	const snapshot = await uploadBytes(storageRef, selectedImage);
+	const imageUrl = await getDownloadURL(snapshot.ref);
+
+	await setDoc(doc(database, FileType.Image, selectedImage.name), {
+		name: selectedImage.name,
+		url: imageUrl,
+		createdAt: new Date(),
+		altText: altText,
+		imageCaption: caption,
+	} as ImageDocument);
+
+	return { url: imageUrl, ref: snapshot.ref };
 };
 
 // Delete an image from storage


### PR DESCRIPTION
## Summary
- `uploadImage` in `fileService.ts` caught all Firebase errors silently and returned `undefined`, crashing callers that accessed `.url` on the result
- Removed the error-swallowing `try/catch` so errors propagate to the caller's existing error-toast handler
- Removed redundant inner `if (newImage)` check in `uploadNewsImage` and `uploadEventImage`
- Added JSDoc to all three functions

## Test plan
- [ ] Upload an image on a news item → succeeds as before
- [ ] Upload an image on an event → succeeds as before
- [ ] Network error during upload → error toast appears instead of silent crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 📋 Changelog

### Added
### Changed
### Fixed
- Fix: uploadImage in fileService no longer silently swallows Firebase errors — errors now propagate to callers so upload failures are correctly surfaced as error toasts to the user
- Removed redundant double-null-check in uploadNewsImage and uploadEventImage