### PR TITLE
fix: events starting today no longer fail start-date validation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,7 +21,7 @@ Patch: Any other tag or no tag → bumps patch version (1.0.0 → 1.0.1)
 
 ### Fixed
 
--
+- Fix: events with a start date of today were incorrectly rejected with "start date cannot be in the past" — the check now compares dates at midnight rather than against the current wall-clock time
 
 ## [8.1.1] - 2026-06-07
 

--- a/src/lib/services/validateForm.ts
+++ b/src/lib/services/validateForm.ts
@@ -5,6 +5,12 @@ export interface FormData {
 	target: Record<string, { name: string; required: boolean; value: string }>;
 }
 
+/**
+ * Checks all required fields in a form and returns the names of any that are empty.
+ *
+ * @param formData - The form data object containing field definitions and values
+ * @returns An array of field names that are required but have no value; empty array if all fields are filled
+ */
 export function validateEmptyInput(formData: FormData): string[] {
 	if (!formData.target) {
 		return [];
@@ -18,13 +24,40 @@ export function validateEmptyInput(formData: FormData): string[] {
 	return errObject;
 }
 
+/**
+ * Builds a Date object from separate date and time strings, interpreted as LOCAL time.
+ *
+ * IMPORTANT: The strings are joined with 'T' but WITHOUT a trailing 'Z' timezone suffix.
+ * This is intentional — omitting 'Z' causes the browser to interpret the result as local
+ * time rather than UTC. All user-facing date/time inputs in this app are in local time.
+ *
+ * @param date - A date string in 'YYYY-MM-DD' format
+ * @param time - A time string in 'HH:MM' format
+ * @returns A Date object representing the given date and time in the user's local timezone
+ */
 export const buildTimeStamp = (date: string, time: string): Date => {
 	return new Date(`${date}T${time}`);
 };
 
+/**
+ * Validates all date and time fields of an event and shows error toasts for any violations.
+ *
+ * Checks performed:
+ * - Start date and time are present
+ * - End date and time are present
+ * - Start date is not in the past (date-level comparison: yesterday or earlier is rejected,
+ *   today is allowed regardless of the current time of day)
+ * - End date/time is not before or equal to start date/time
+ * - Publish date is not later than the start date
+ * - Unpublish date is not before or equal to the publish date
+ *
+ * @param event - The event object to validate
+ * @returns true if any validation error was found (the event is NOT valid), false if all checks pass
+ * @throws Error if the event object itself is null or undefined
+ */
 export function validateEventData(event: DomainEvent): boolean {
 	if (!event) {
-		throw new Error('Event could be found');
+		throw new Error('Event could not be found');
 	}
 
 	const { startdate, starttime, enddate, endtime, publishdate, publishtime, unpublishdate, unpublishtime } = event;
@@ -52,7 +85,12 @@ export function validateEventData(event: DomainEvent): boolean {
 		hasError = true;
 	}
 
-	if (new Date(startdate) < new Date()) {
+	// Compare the selected start date against midnight of today (not the current time).
+	// Using new Date().toDateString() gives us 'Mon Jun 07 2026', which parses back to
+	// midnight local time — the same representation used by new Date(startdate).
+	// This means 'today' is always allowed, only dates before today are rejected.
+	const todayAtMidnight = new Date(new Date().toDateString());
+	if (startdate && new Date(startdate) < todayAtMidnight) {
 		notificationStore.addToast('error', 'The start date cannot be in the past');
 		hasError = true;
 	}


### PR DESCRIPTION
## Summary
- `validateEventData` compared `new Date(startdate)` (midnight) against `new Date()` (current wall-clock time) — so any event scheduled for today was rejected during business hours
- Fix compares against midnight of today using `new Date(new Date().toDateString())`, making it a date-level comparison
- Also fixed typo: `'Event could be found'` → `'Event could not be found'`
- Added JSDoc to all three exported functions including the important `buildTimeStamp` no-Z-suffix invariant

## Test plan
- [ ] Create an event with start date = today, start time = in the future → should be accepted
- [ ] Create an event with start date = yesterday → should still be rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 📋 Changelog

### Added
### Changed
### Fixed
- Fix: events with a start date of today were incorrectly rejected with "start date cannot be in the past" — the check now compares dates at midnight rather than against the current wall-clock time

### Added
### Changed
### Fixed
- Fix: events with a start date of today were incorrectly rejected with "start date cannot be in the past" — the check now compares dates at midnight rather than against the current wall-clock time