### PR TITLE
fix: use local date methods when defaulting event publish date

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,7 +21,7 @@ Patch: Any other tag or no tag → bumps patch version (1.0.0 → 1.0.1)
 
 ### Fixed
 
--
+- Fix: eventFormService now uses local date methods instead of toISOString() when defaulting the publish date — prevents users west of UTC from getting yesterday's date assigned after midnight local time (same fix already applied to newsFormService in 7.3.0)
 
 ## [8.1.0] - 2026-06-06
 

--- a/src/lib/services/EventFormService.ts
+++ b/src/lib/services/EventFormService.ts
@@ -8,13 +8,15 @@ export const eventFormService = async (newEvent: DomainEvent) => {
 	// Add calculated Date values
 	// Set publish date to now if not defined
 	if (!newEvent.publishdate) {
-		newEvent.publishdate = new Date().toISOString().split('T')[0];
-		const currentTime = new Date();
-		newEvent.publishtime = currentTime.toLocaleTimeString('en-US', {
-			hour: '2-digit',
-			minute: '2-digit',
-			hour12: false,
-		});
+		// Build the date and time strings using local date methods, NOT toISOString().
+		// toISOString() returns a UTC string — for users west of UTC this can produce
+		// yesterday's date after midnight local time (e.g. 23:00 CET = 22:00 UTC = previous day).
+		// Using getFullYear/getMonth/getDate/getHours/getMinutes gives the correct local values.
+		// NewsFormService.ts uses the same approach.
+		const now = new Date();
+		const pad = (n: number) => String(n).padStart(2, '0');
+		newEvent.publishdate = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+		newEvent.publishtime = `${pad(now.getHours())}:${pad(now.getMinutes())}`;
 	}
 
 	// Set publish time to 09:00 if not defined


### PR DESCRIPTION
## Summary
- `eventFormService` used `new Date().toISOString().split('T')[0]` for the default publish date — `toISOString()` returns UTC, so users west of UTC could get yesterday's date after midnight local time
- `newsFormService` already used the correct local-date approach (`getFullYear/getMonth/getDate`)
- Fix: aligned `eventFormService` with the same pattern

## Test plan
- [ ] Create an event without a publish date at e.g. 23:30 local time (relevant in UTC-offset timezones) → publish date should be today, not tomorrow/yesterday

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 📋 Changelog

### Added
### Changed
### Fixed
- Fix: eventFormService now uses local date methods instead of toISOString() when defaulting the publish date — prevents users west of UTC from getting yesterday's date assigned after midnight local time (same fix already applied to newsFormService in 7.3.0)

### Added
### Changed
### Fixed
- Fix: eventFormService now uses local date methods instead of toISOString() when defaulting the publish date — prevents users west of UTC from getting yesterday's date assigned after midnight local time (same fix already applied to newsFormService in 7.3.0)